### PR TITLE
Allow to extract framerate from `OtherStream`s

### DIFF
--- a/ext/mediainfo_native/basestream.cpp
+++ b/ext/mediainfo_native/basestream.cpp
@@ -31,12 +31,13 @@ VALUE stream_klasses[STREAM_TYPE_MAX];
 void Init_BaseStream(VALUE mMediaInfoNative)
 {
   VALUE cBaseStream = rb_define_class_under(mMediaInfoNative, "BaseStream", rb_cObject);
+  VALUE cBaseStreamWithFramerate = rb_define_class_under(mMediaInfoNative, "BaseStreamWithFramerate", cBaseStream);
 
   stream_klasses[GENERAL] = rb_define_class_under(mMediaInfoNative, "GeneralStream", cBaseStream);
-  stream_klasses[VIDEO]   = rb_define_class_under(mMediaInfoNative, "VideoStream", cBaseStream);
+  stream_klasses[VIDEO]   = rb_define_class_under(mMediaInfoNative, "VideoStream", cBaseStreamWithFramerate);
   stream_klasses[AUDIO]   = rb_define_class_under(mMediaInfoNative, "AudioStream", cBaseStream);
   stream_klasses[TEXT]    = rb_define_class_under(mMediaInfoNative, "TextStream", cBaseStream);
-  stream_klasses[OTHER]   = rb_define_class_under(mMediaInfoNative, "OtherStream", cBaseStream);
+  stream_klasses[OTHER]   = rb_define_class_under(mMediaInfoNative, "OtherStream", cBaseStreamWithFramerate);
   stream_klasses[IMAGE]   = rb_define_class_under(mMediaInfoNative, "ImageStream", cBaseStream);
   stream_klasses[MENU]    = rb_define_class_under(mMediaInfoNative, "MenuStream", cBaseStream);
 

--- a/lib/mediainfo-native.rb
+++ b/lib/mediainfo-native.rb
@@ -2,6 +2,7 @@ require 'mediainfo_native.so'
 
 require 'mediainfo-native/attr_readers'
 require 'mediainfo-native/base_stream'
+require 'mediainfo-native/base_stream_with_framerate'
 require 'mediainfo-native/streams/audio'
 require 'mediainfo-native/streams/general'
 require 'mediainfo-native/streams/image'

--- a/lib/mediainfo-native/base_stream_with_framerate.rb
+++ b/lib/mediainfo-native/base_stream_with_framerate.rb
@@ -1,0 +1,9 @@
+module MediaInfoNative
+  class BaseStreamWithFramerate < BaseStream
+    mediainfo_attr_reader :frame_rate, 'FrameRate'
+    def fps
+      frame_rate[/[\d.]+/].to_f if frame_rate
+    end
+    alias_method :framerate, :fps
+  end
+end

--- a/lib/mediainfo-native/streams/other.rb
+++ b/lib/mediainfo-native/streams/other.rb
@@ -1,5 +1,5 @@
 module MediaInfoNative
-  class OtherStream < BaseStream
+  class OtherStream < BaseStreamWithFramerate
     mediainfo_attr_reader :stream_id, 'ID'
     mediainfo_attr_reader :type, 'Type'
     mediainfo_attr_reader :timecode, 'TimeCode_FirstFrame'

--- a/lib/mediainfo-native/streams/video.rb
+++ b/lib/mediainfo-native/streams/video.rb
@@ -1,5 +1,5 @@
 module MediaInfoNative
-  class VideoStream < BaseStream
+  class VideoStream < BaseStreamWithFramerate
     mediainfo_attr_reader :stream_id, 'ID'
     
     mediainfo_duration_reader :duration, 'Duration'
@@ -56,12 +56,6 @@ module MediaInfoNative
     mediainfo_attr_reader :codec_info, 'CodecID/Info'
     mediainfo_attr_reader :codec, 'Codec'
     alias_method :codec_id_info, :codec_info
-
-    mediainfo_attr_reader :frame_rate, 'FrameRate'
-    def fps
-      frame_rate[/[\d.]+/].to_f if frame_rate
-    end
-    alias_method :framerate, :fps
 
     mediainfo_attr_reader :nominal_frame_rate, 'FrameRate_Nominal'
     def nominal_fps


### PR DESCRIPTION
The `OtherStream` class is also representing time code streams. It is possible that the framerate of the time code does not match the video streams. This exposes the framerate of the timecode if it is available.