### PR TITLE
Fix compilation and initialization warning on Ruby 3.4, setup CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: [develop]
+  pull_request:
+    branches: [develop]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version: ["3.1", "3.4"]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+      - name: Install dependencies
+        run: |
+          sudo apt-get update && sudo apt-get install -y libmediainfo-dev
+          bundle install
+      - name: Run tests
+        run: bundle exec rake

--- a/Rakefile
+++ b/Rakefile
@@ -6,3 +6,5 @@ Rake::ExtensionTask.new('mediainfo_native')
 desc "Run the specs."
 RSpec::Core::RakeTask.new('spec')
 task spec: [:clean, :compile]
+
+task default: :spec

--- a/ext/mediainfo_native/MediaInfoDLL.h
+++ b/ext/mediainfo_native/MediaInfoDLL.h
@@ -15,9 +15,12 @@
 #ifndef MediaInfoDLLH
 #define MediaInfoDLLH
 
-
+#ifndef UNICODE
 #define UNICODE
+#endif
+#ifndef _UNICODE
 #define _UNICODE
+#endif
 
 //***************************************************************************
 // Platforms (from libzen)

--- a/ext/mediainfo_native/basestream.cpp
+++ b/ext/mediainfo_native/basestream.cpp
@@ -31,7 +31,9 @@ VALUE stream_klasses[STREAM_TYPE_MAX];
 void Init_BaseStream(VALUE mMediaInfoNative)
 {
   VALUE cBaseStream = rb_define_class_under(mMediaInfoNative, "BaseStream", rb_cObject);
+  rb_undef_alloc_func(cBaseStream);
   VALUE cBaseStreamWithFramerate = rb_define_class_under(mMediaInfoNative, "BaseStreamWithFramerate", cBaseStream);
+  rb_undef_alloc_func(cBaseStreamWithFramerate);
 
   stream_klasses[GENERAL] = rb_define_class_under(mMediaInfoNative, "GeneralStream", cBaseStream);
   stream_klasses[VIDEO]   = rb_define_class_under(mMediaInfoNative, "VideoStream", cBaseStreamWithFramerate);
@@ -42,6 +44,7 @@ void Init_BaseStream(VALUE mMediaInfoNative)
   stream_klasses[MENU]    = rb_define_class_under(mMediaInfoNative, "MenuStream", cBaseStream);
 
   for(unsigned int st = 0; st < STREAM_TYPE_MAX; ++st) {
+    rb_undef_alloc_func(stream_klasses[st]);
     rb_define_method(stream_klasses[st], "lookup", (VALUE(*)(...)) bs_lookup, 1);
   }
 }

--- a/ext/mediainfo_native/mediainfo_wrapper.cpp
+++ b/ext/mediainfo_native/mediainfo_wrapper.cpp
@@ -123,6 +123,7 @@ extern "C"
 void Init_MediaInfoWrapper(VALUE mMediaInfoNative)
 {
   VALUE cMediaInfo = rb_define_class_under(mMediaInfoNative, "MediaInfo", rb_cObject);
+  rb_undef_alloc_func(cMediaInfo);
 
   rb_define_singleton_method(cMediaInfo, "new", (RUBYFUNC) miw_new, -2);
 

--- a/ext/mediainfo_native/mediainfo_wrapper.cpp
+++ b/ext/mediainfo_native/mediainfo_wrapper.cpp
@@ -12,7 +12,7 @@ namespace MediaInfoNative
 
 #define GET_WRAPPER(var) \
   MediaInfoWrapper* var; \
-  Data_Get_Struct(self, MediaInfoWrapper, var)
+  TypedData_Get_Struct(self, MediaInfoWrapper, &mediainfo_wrapper_type, var)
 
 typedef struct {
   MediaInfoWrapper* miw;
@@ -23,12 +23,21 @@ typedef struct {
 extern "C"
 {
 
-  typedef VALUE(*RUBYFUNC)(...);
-
   static void miw_free(void* ptr) 
   {
     delete ((MediaInfoWrapper*) ptr);
   }
+
+  static const rb_data_type_t mediainfo_wrapper_type = {
+    "MediaInfoWrapper",
+    {
+      nullptr, // mark function
+      miw_free, // free function
+      nullptr,  // memsize function
+    },
+    nullptr, nullptr, // parent, data
+    RUBY_TYPED_FREE_IMMEDIATELY
+  };
 
   static VALUE miw_new(VALUE klass, VALUE args)
   {
@@ -46,7 +55,7 @@ extern "C"
     }
 
     MediaInfoWrapper* miw = new MediaInfoWrapper(ignore_continuous_file_names);
-    return Data_Wrap_Struct(klass, 0, miw_free, miw);
+    return TypedData_Wrap_Struct(klass, &mediainfo_wrapper_type, miw);
   }
 
   static VALUE miw_close(VALUE self)
@@ -79,7 +88,7 @@ extern "C"
     }
 
     if(rb_block_given_p())
-      return rb_ensure((RUBYFUNC) rb_yield, Qnil, (RUBYFUNC) miw_close, self);
+      return rb_ensure(rb_yield, Qnil, miw_close, self);
     else
       return Qnil;
   }
@@ -125,15 +134,15 @@ void Init_MediaInfoWrapper(VALUE mMediaInfoNative)
   VALUE cMediaInfo = rb_define_class_under(mMediaInfoNative, "MediaInfo", rb_cObject);
   rb_undef_alloc_func(cMediaInfo);
 
-  rb_define_singleton_method(cMediaInfo, "new", (RUBYFUNC) miw_new, -2);
+  rb_define_singleton_method(cMediaInfo, "new", RUBY_METHOD_FUNC(miw_new), -2);
 
-  rb_define_method(cMediaInfo, "close", (RUBYFUNC) miw_close, 0);
-  rb_define_method(cMediaInfo, "open", (RUBYFUNC) miw_open, 1);
-  rb_define_method(cMediaInfo, "is_open?", (RUBYFUNC) miw_is_open, 0);
-  rb_define_method(cMediaInfo, "streams", (RUBYFUNC) miw_streams, 0);
+  rb_define_method(cMediaInfo, "close", RUBY_METHOD_FUNC(miw_close), 0);
+  rb_define_method(cMediaInfo, "open", RUBY_METHOD_FUNC(miw_open), 1);
+  rb_define_method(cMediaInfo, "is_open?", RUBY_METHOD_FUNC(miw_is_open), 0);
+  rb_define_method(cMediaInfo, "streams", RUBY_METHOD_FUNC(miw_streams), 0);
 
-  rb_define_method(cMediaInfo, "inform", (RUBYFUNC) miw_inform, 1);
-  rb_define_method(cMediaInfo, "option", (RUBYFUNC) miw_option, 0);
+  rb_define_method(cMediaInfo, "inform", RUBY_METHOD_FUNC(miw_inform), 1);
+  rb_define_method(cMediaInfo, "option", RUBY_METHOD_FUNC(miw_option), 0);
 }
 
 /* ************************** MediaInfoWrapper ****************************** */
@@ -158,6 +167,9 @@ MediaInfoDLL::stream_t convertToMediaInfoStreamType(StreamType type)
     return MediaInfoDLL::Stream_Image;
   case MENU:
     return MediaInfoDLL::Stream_Menu;
+  default:
+    rb_raise(rb_eRuntimeError, "Invalid stream type: %d", (int)type);
+    __builtin_unreachable();
   }
 }
 


### PR DESCRIPTION
Fixes initialization warning on Ruby 3.4:

```
warning: undefining the allocator of T_DATA class MediaInfoNative::MediaInfo
```

Fix compilation warnings, see https://github.com/projectivetech/mediainfo-native/actions/runs/18474392592/job/52635558172?pr=7#step:5:17

Setup CI using GitHub actions